### PR TITLE
cache `canSymlink` result to avoid performance penalty

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,11 +85,21 @@ function makeFSObjectCleanedUp(p) {
   return makeFSObjectCleanedUp(target);
 }
 
+// Cache the result of `canSymlink`. Since it uses fs methods
+// it is moderately expensive to repeat many times.
+let cachedCanSymlink = undefined;
+function checkCanSymlink() {
+  if (cachedCanSymlink === undefined) {
+    cachedCanSymlink = canSymlink();
+  }
+  return cachedCanSymlink;
+}
+
 class FSUpdater {
   constructor(outputPath, options) {
     this.outputPath = outputPath;
     if (options == null) options = {};
-    if (options.canSymlink == null) options.canSymlink = canSymlink();
+    if (options.canSymlink == null) options.canSymlink = checkCanSymlink();
     if (options.retry == null) options.retry = true;
     this.options = options;
     this._logger = loggerGen("FSUpdater");


### PR DESCRIPTION
In a build with a large amount of FSUpdater instances created, the performance hit from `testCanSymlink` is substantial - over 2.5 seconds in my case, with that time coming from redundant calls to various fs methods:

<img width="723" alt="Screenshot 2023-10-09 at 4 33 26 PM" src="https://github.com/raycohen/node-fs-updater/assets/20404/8c1efe6d-7e25-43ca-bce3-ee9000ae09f4">
